### PR TITLE
Import Data.ByteString.Char8 to make it compile on Debian 7

### DIFF
--- a/src/Network/Protocol/NetSNMP.hsc
+++ b/src/Network/Protocol/NetSNMP.hsc
@@ -37,6 +37,7 @@ import           Data.List
 import           Foreign hiding (void)
 import           Foreign.C.String
 import           Foreign.C.Types
+import           Data.ByteString.Char8 ()
 
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>


### PR DESCRIPTION
The error message was:

```
src/Network/Protocol/NetSNMP.hsc:505:27:
    No instance for (Data.String.IsString ByteString)
      arising from the literal `"."'
    Possible fix:
      add an instance declaration for (Data.String.IsString ByteString)
    In the first argument of `B.intercalate', namely `"."'
    In the expression: B.intercalate "." (map (B.pack . (: [])) octets)
    In an equation for `str':
        str = B.intercalate "." (map (B.pack . (: [])) octets)
```
